### PR TITLE
Overhaul mobile UI: swipe gestures, tabs, better touch targets

### DIFF
--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -1,27 +1,50 @@
 import React from "react";
-
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
 
 const ActionContainer = styled("div")`
-  margin-bottom: 1rem;
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
 `;
 
 const Btn = styled("button")`
-  border: 1px solid #b2002a;
-  padding: 3px 10px;
-  color: #b2002a;
-  border-radius: 4px;
-  background-color: #44000a;
+  height: 34px;
+  min-width: 34px;
+  padding: 0 12px;
+  border-radius: 17px;
+  font-size: 0.85em;
+  font-weight: 700;
   cursor: pointer;
-  margin-left: 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  transition: transform 0.1s, filter 0.1s;
+
+  &:active {
+    transform: scale(0.88);
+    filter: brightness(0.8);
+  }
+`;
+
+const DeleteBtn = styled(Btn)`
+  background: rgba(255, 60, 60, 0.12);
+  color: #ff7777;
+  border: 1px solid rgba(255, 60, 60, 0.3);
+`;
+
+const SaveBtn = styled(Btn)`
+  background: rgba(50, 210, 100, 0.1);
+  color: #55ee99;
+  border: 1px solid rgba(50, 210, 100, 0.25);
 `;
 
 const CardActions = ({ onDelete, onStashed }) => (
   <ActionContainer>
-    <Btn onClick={onDelete}>del</Btn>
-    <Btn onClick={onStashed}>save</Btn>
+    <DeleteBtn onClick={onDelete}>✕</DeleteBtn>
+    <SaveBtn onClick={onStashed}>✓</SaveBtn>
   </ActionContainer>
 );
 

--- a/src/Card/e-card.js
+++ b/src/Card/e-card.js
@@ -1,62 +1,75 @@
-import styled from '@emotion/styled'
-import { css } from 'emotion'
+import styled from '@emotion/styled';
+import { css } from 'emotion';
 import mq from "../theme/mediaqueries";
 
 const Card = styled("div")`
-  background: linear-gradient(to right, #1f0318, #660014);
-  border-radius: 2px;
-  border: 1px solid #660014;
-  padding: 1em 1em 0;
+  background: linear-gradient(145deg, #280420, #6a0018);
+  border-radius: 10px;
+  border: 1px solid rgba(150, 0, 40, 0.5);
+  padding: 0.85em 0.85em 0.6em;
   color: white;
   height: 100%;
   position: relative;
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  transition: transform 0.12s;
+
+  &:active {
+    transform: scale(0.97);
+  }
 `;
 
 export const CardShower = styled("div")`
   display: grid;
-  grid-template-columns: 1fr;
-  grid-gap: 0.8em;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.55em;
+  padding-bottom: 1rem;
 
   ${mq.medium(css`
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   `)};
 `;
 
 export const Title = styled("h3")`
-  font-size: 0.9em;
+  font-size: 0.88em;
+  line-height: 1.4;
+  color: white;
+  font-weight: 600;
 `;
 
 export const Author = styled("span")`
-  display: inline-block;
-  text-align: center;
-  color: #ffcbb7;
-  font-size: ${({ big }) => (big ? "1em" : "0.4em")};
-  padding: 0 0 0.4em;
+  display: block;
+  color: rgba(255, 200, 160, 0.6);
+  font-size: 0.72em;
+  margin-top: 0.35em;
 `;
 
 export const Score = styled("div")`
-  text-align: center;
-  color: #c8e6fc;
   position: absolute;
-  font-size: ${({ big }) => (big ? "3.5em" : "2.4em")};
-  right: 0;
-  bottom: -10px;
-  font-weight: bold;
-  opacity: 0.4;
+  right: 0.4rem;
+  bottom: -0.2rem;
+  font-size: 2em;
+  font-weight: 900;
+  opacity: 0.2;
+  color: white;
 `;
 
 export const Loader = styled("div")`
   text-align: center;
-  color: white;
+  color: rgba(255, 255, 255, 0.6);
   min-height: 300px;
   display: flex;
   justify-content: center;
   align-items: center;
+  font-size: 0.85em;
+  letter-spacing: 0.08em;
 `;
 
 export const ColorCue = styled("div")`
   background-color: ${({ background }) => background};
-  height: 5px;
-  margin-bottom: 10px;
+  height: 4px;
+  margin: -0.85em -0.85em 0.75em;
+  border-radius: 10px 10px 0 0;
 `;
+
 export default Card;

--- a/src/PrimaryCard.js
+++ b/src/PrimaryCard.js
@@ -1,24 +1,25 @@
-import React, { Component, useEffect } from "react";
-import CardContainer, { Author, ColorCue } from "./Card/e-card";
+import React, { useEffect, useRef, useState } from "react";
+import CardContainer, { ColorCue } from "./Card/e-card";
 import color from "./Card/e-palette";
-import CardActions from "./Card/CardActions";
-import styled from '@emotion/styled'
-import { css } from 'emotion'
-
+import styled from '@emotion/styled';
+import { css } from 'emotion';
 import Center from "./Center";
 import mq from "./theme/mediaqueries";
 
-const PrimaryContainer = styled("div")`
-  margin-bottom: 2rem;
+const PrimaryWrap = styled("div")`
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  height: calc(100% - 100px);
+  margin-bottom: 1.25rem;
+  padding: 0 0.5rem;
 `;
 
 const Sizer = styled("div")`
   width: 100%;
-  height: 60vh;
+  max-width: 600px;
+  height: 52vh;
+  position: relative;
+  user-select: none;
 
   ${mq.medium(css`
     width: 80%;
@@ -26,69 +27,193 @@ const Sizer = styled("div")`
   `)};
 `;
 
-
- const Score = styled("div")`
-  text-align: center;
-  color: #c8e6fc;
-  font-size: ${({ big }) => (big ? "3.5em" : "2.4em")};
-  font-weight: bold;
-  opacity: 0.4;
+const CardWrap = styled("div")`
+  width: 100%;
+  height: 100%;
 `;
 
-export const Title = styled("h3")`
-  font-size: 1.6em;
+const ScoreDisplay = styled("div")`
+  font-size: 3.5em;
+  font-weight: 900;
+  color: ${({ scoreColor }) => scoreColor};
+  line-height: 1;
+  letter-spacing: -2px;
+  margin-bottom: 0.3rem;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5);
 `;
 
-const PrimaryCard = ({
-  url,
-  score,
-  id,
-  saveSeen,
-  onDelete,
-  onStashed,
-  title,
-  by,
-}) => {
+const TitleDisplay = styled("h3")`
+  font-size: 1.3em;
+  line-height: 1.4;
+  font-weight: 700;
+  color: white;
+  margin: 0;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+`;
+
+const AuthorDisplay = styled("div")`
+  font-size: 0.8em;
+  color: rgba(255, 200, 160, 0.65);
+  margin-top: 0.65rem;
+`;
+
+const SwipeOverlay = styled("div")`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: ${({ side }) => side === 'left' ? 'flex-start' : 'flex-end'};
+  padding: 1.5rem;
+  pointer-events: none;
+  z-index: 10;
+  opacity: ${({ opacity }) => opacity};
+`;
+
+const SwipeLabel = styled("div")`
+  font-size: 2em;
+  font-weight: 900;
+  padding: 0.25rem 0.75rem;
+  border-radius: 8px;
+  border: 3px solid ${({ type }) => type === 'skip' ? '#ff5555' : '#44dd88'};
+  color: ${({ type }) => type === 'skip' ? '#ff5555' : '#44dd88'};
+  transform: rotate(${({ type }) => type === 'skip' ? '10deg' : '-10deg'});
+  letter-spacing: 0.05em;
+`;
+
+const SwipeHints = styled("div")`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 600px;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.62em;
+  color: rgba(255, 255, 255, 0.2);
+  letter-spacing: 0.05em;
+`;
+
+const ActionRow = styled("div")`
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  width: 100%;
+  max-width: 600px;
+  padding: 0 0.25rem;
+`;
+
+const ActionBtn = styled("button")`
+  flex: 1;
+  height: 50px;
+  border-radius: 25px;
+  font-size: 1em;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  font-family: 'Montserrat', sans-serif;
+  transition: transform 0.12s, filter 0.12s;
+
+  &:active {
+    transform: scale(0.93);
+    filter: brightness(0.8);
+  }
+`;
+
+const SkipBtn = styled(ActionBtn)`
+  background: rgba(255, 55, 55, 0.13);
+  color: #ff7777;
+  border: 1.5px solid rgba(255, 55, 55, 0.3);
+`;
+
+const SaveBtn = styled(ActionBtn)`
+  background: rgba(50, 210, 100, 0.12);
+  color: #55ee99;
+  border: 1.5px solid rgba(50, 210, 100, 0.28);
+`;
+
+const PrimaryCard = ({ url, score, id, saveSeen, onDelete, onStashed, title, by }) => {
+  const [offset, setOffset] = useState(0);
+  const touchStartX = useRef(null);
+  const touching = useRef(false);
 
   useEffect(() => {
-    const el = document.addEventListener("keyup", (e) => {
-      if (e.key === "ArrowLeft") {
-        onDelete(id);
-      }
+    const handler = (e) => {
+      if (e.key === "ArrowLeft") onDelete(id);
+      if (e.key === "ArrowRight") onStashed(id);
+    };
+    document.addEventListener("keyup", handler);
+    return () => document.removeEventListener("keyup", handler);
+  }, [id, onDelete, onStashed]);
 
-      if (e.key === "ArrowRight") {
-        onStashed(id);
-      }
-    });
-    return () => document.removeEventListener("keyup", el);
-  }, []);
+  const onTouchStart = (e) => {
+    touchStartX.current = e.touches[0].clientX;
+    touching.current = true;
+  };
+
+  const onTouchMove = (e) => {
+    if (!touching.current) return;
+    setOffset(e.touches[0].clientX - touchStartX.current);
+  };
+
+  const onTouchEnd = () => {
+    if (Math.abs(offset) > 90) {
+      if (offset < 0) onDelete(id);
+      else onStashed(id);
+    }
+    setOffset(0);
+    touching.current = false;
+  };
+
+  const swipeProgress = Math.min(Math.abs(offset) / 90, 1);
+  const scoreColor = color(score);
 
   return (
-    <PrimaryContainer>
-      <Sizer>
-        <a href={url} target="_blank">
-          <CardContainer background={color(score)} onClick={() => saveSeen(id)}>
-            <CardActions
-              onDelete={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                onDelete(id);
-              }}
-              onStashed={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                onStashed(id);
-              }}
-            />
-            <ColorCue background={color(score)} />
-            <Center vertical height="calc(100% - 100px)">
-              <Score>{score}</Score>
-              <Title>{title}</Title>
-            </Center>
-          </CardContainer>
-        </a>
+    <PrimaryWrap>
+      <Sizer
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+      >
+        <CardWrap
+          style={{
+            transform: `translateX(${offset}px) rotate(${offset * 0.04}deg)`,
+            transition: touching.current ? 'none' : 'transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+          }}
+        >
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            <CardContainer background={scoreColor} onClick={() => saveSeen(id)}>
+              {offset < -20 && (
+                <SwipeOverlay side="left" opacity={swipeProgress}>
+                  <SwipeLabel type="skip">SKIP</SwipeLabel>
+                </SwipeOverlay>
+              )}
+              {offset > 20 && (
+                <SwipeOverlay side="right" opacity={swipeProgress}>
+                  <SwipeLabel type="save">SAVE</SwipeLabel>
+                </SwipeOverlay>
+              )}
+              <ColorCue background={scoreColor} />
+              <Center vertical height="calc(100% - 60px)">
+                <ScoreDisplay scoreColor={scoreColor}>{score}</ScoreDisplay>
+                <TitleDisplay>{title}</TitleDisplay>
+                <AuthorDisplay>by {by}</AuthorDisplay>
+              </Center>
+            </CardContainer>
+          </a>
+        </CardWrap>
       </Sizer>
-    </PrimaryContainer>
+      <SwipeHints>
+        <span>← swipe to skip</span>
+        <span>swipe to save →</span>
+      </SwipeHints>
+      <ActionRow>
+        <SkipBtn onClick={() => onDelete(id)}>✕ Skip</SkipBtn>
+        <SaveBtn onClick={() => onStashed(id)}>✓ Save</SaveBtn>
+      </ActionRow>
+    </PrimaryWrap>
   );
 };
 

--- a/src/e-layout.js
+++ b/src/e-layout.js
@@ -1,37 +1,41 @@
-import styled from '@emotion/styled'
+import styled from '@emotion/styled';
 
 export const App = styled("div")`
   font-family: "Montserrat", sans-serif;
-  background: linear-gradient(to bottom, #1f0318, #660014);
+  background: linear-gradient(to bottom, #1a0215, #5c0010);
   text-align: center;
-  padding: 1.5em;
+  padding: 1.25em 1em;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
 `;
+
 const Title = styled("h3")`
-  padding: 0 0 1.6em;
+  padding: 0 0 1.1em;
   color: white;
   text-align: center;
-  font-size: 0.8em;
+  font-size: 0.9em;
   font-family: "Roboto", sans-serif;
+  letter-spacing: 0.04em;
 `;
 
 export const H = styled("span")`
-  font-weight: 400;
+  font-weight: 700;
+  color: #ff6600;
+  font-size: 1.15em;
 `;
 
 export const Rest = styled("span")`
-  font-weight: 100;
+  font-weight: 300;
   opacity: 0.5;
-  font-size: 1.3em;
+  font-size: 1.1em;
 `;
 
 export const Footer = styled("footer")`
   text-align: center;
-  font-size: 0.8em;
-  padding-top: 1em;
-  color: #eee;
+  font-size: 0.72em;
+  padding-top: 1.25em;
+  color: rgba(255, 255, 255, 0.3);
 `;
 
 export const Main = styled("main")`

--- a/src/shower.js
+++ b/src/shower.js
@@ -1,14 +1,49 @@
 import React, { Component } from "react";
+import styled from '@emotion/styled';
 import news from "./news.service";
 import { CardShower, Loader } from "./Card/e-card";
 import Card from "./card";
 import PrimaryCard from "./PrimaryCard";
 import Center from "./Center";
-import { H2, Message } from "./Card/e-elements";
+import { Message } from "./Card/e-elements";
+
+const TabBar = styled("div")`
+  display: flex;
+  margin: 0 auto 1.25rem;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 10px;
+  padding: 4px;
+  width: fit-content;
+`;
+
+const Tab = styled("button")`
+  padding: 8px 24px;
+  border: none;
+  background: ${({ isActive }) => isActive ? 'rgba(255, 255, 255, 0.14)' : 'transparent'};
+  color: ${({ isActive }) => isActive ? 'white' : 'rgba(255, 255, 255, 0.38)'};
+  border-radius: 8px;
+  font-size: 0.85em;
+  font-weight: ${({ isActive }) => isActive ? '700' : '400'};
+  cursor: pointer;
+  font-family: 'Montserrat', sans-serif;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.18s, color 0.18s;
+`;
+
+const Counter = styled("div")`
+  text-align: center;
+  color: rgba(255, 255, 255, 0.26);
+  font-size: 0.7em;
+  margin-bottom: 0.6rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+`;
+
 export default class Shower extends Component {
   state = {
     data: [],
     loading: true,
+    tab: 'feed',
     elementsSeen: JSON.parse(localStorage.getItem("seen") || "[]"),
     elementsDeleted: JSON.parse(localStorage.getItem("deleted") || "[]"),
     elementsStashed: JSON.parse(localStorage.getItem("stashed") || "[]"),
@@ -18,107 +53,119 @@ export default class Shower extends Component {
     news().then((results) => this.setState({ data: results, loading: false }));
   }
 
-  saveSeen = (id) => {
-    localStorage.setItem(
-      "seen",
-      JSON.stringify([...this.state.elementsSeen, id])
-    );
+  setTab = (tab) => this.setState({ tab });
 
-    this.setState({ elementsSeen: [...this.state.elementsSeen, id] });
+  saveSeen = (id) => {
+    const updated = [...this.state.elementsSeen, id];
+    localStorage.setItem("seen", JSON.stringify(updated));
+    this.setState({ elementsSeen: updated });
   };
 
   saveStashed = (id) => {
-    localStorage.setItem(
-      "stashed",
-      JSON.stringify([...this.state.elementsStashed, id])
-    );
-
-    this.setState({ elementsStashed: [...this.state.elementsStashed, id] });
+    const updated = [...this.state.elementsStashed, id];
+    localStorage.setItem("stashed", JSON.stringify(updated));
+    this.setState({ elementsStashed: updated });
   };
 
   onDelete = (id) => {
-    localStorage.setItem(
-      "deleted",
-      JSON.stringify([...this.state.elementsDeleted, id])
-    );
+    const updated = [...this.state.elementsDeleted, id];
+    localStorage.setItem("deleted", JSON.stringify(updated));
+    this.setState({ elementsDeleted: updated });
+  };
 
-    this.setState({ elementsDeleted: [...this.state.elementsDeleted, id] });
+  onUnsave = (id) => {
+    const updated = this.state.elementsStashed.filter(i => i !== id);
+    localStorage.setItem("stashed", JSON.stringify(updated));
+    this.setState({ elementsStashed: updated });
   };
 
   render() {
-    if (!this.state.data.length) return <Loader>Loading...</Loader>;
-    const [firstElement, ...restCards] = this.state.data
-      .filter((el) => !this.state.elementsSeen.includes(el.id))
-      .filter((el) => !this.state.elementsDeleted.includes(el.id))
-      .filter((el) => !this.state.elementsStashed.includes(el.id));
+    const { loading, tab, data, elementsSeen, elementsDeleted, elementsStashed } = this.state;
+
+    if (loading) return <Loader>Loading...</Loader>;
+
+    const feedCards = data
+      .filter(el => !elementsSeen.includes(el.id))
+      .filter(el => !elementsDeleted.includes(el.id))
+      .filter(el => !elementsStashed.includes(el.id));
+
+    const savedStories = data.filter(el => elementsStashed.includes(el.id));
+    const [firstElement, ...restCards] = feedCards;
+
     return (
       <div>
-        {!firstElement && (
-          <Center height="80vh">
-            <Message>We are done! for now...</Message>
-          </Center>
+        <TabBar>
+          <Tab isActive={tab === 'feed'} onClick={() => this.setTab('feed')}>Feed</Tab>
+          <Tab isActive={tab === 'saved'} onClick={() => this.setTab('saved')}>
+            Saved{elementsStashed.length > 0 ? ` (${elementsStashed.length})` : ''}
+          </Tab>
+        </TabBar>
+
+        {tab === 'feed' && (
+          <>
+            {!firstElement && (
+              <Center height="65vh">
+                <Message>All caught up!</Message>
+              </Center>
+            )}
+            {firstElement && (
+              <>
+                <Counter>{feedCards.length} {feedCards.length === 1 ? 'story' : 'stories'} left</Counter>
+                <PrimaryCard
+                  key={firstElement.id}
+                  title={firstElement.title}
+                  by={firstElement.by}
+                  score={firstElement.score}
+                  url={firstElement.url}
+                  id={firstElement.id}
+                  saveSeen={this.saveSeen}
+                  onDelete={this.onDelete}
+                  onStashed={this.saveStashed}
+                />
+              </>
+            )}
+            <CardShower>
+              {restCards.map(el => (
+                <Card
+                  key={el.id}
+                  title={el.title}
+                  by={el.by}
+                  score={el.score}
+                  url={el.url}
+                  id={el.id}
+                  saveSeen={this.saveSeen}
+                  onDelete={this.onDelete}
+                  onStashed={this.saveStashed}
+                />
+              ))}
+            </CardShower>
+          </>
         )}
-        {firstElement && (
-          <PrimaryCard
-            key={firstElement.id}
-            title={firstElement.title}
-            by={firstElement.by}
-            score={firstElement.score}
-            url={firstElement.url}
-            id={firstElement.id}
-            saveSeen={this.saveSeen}
-            onDelete={this.onDelete}
-            onStashed={this.saveStashed}
-          />
+
+        {tab === 'saved' && (
+          <>
+            {savedStories.length === 0 && (
+              <Center height="65vh">
+                <Message>No saved stories yet</Message>
+              </Center>
+            )}
+            <CardShower>
+              {savedStories.map(el => (
+                <Card
+                  key={el.id}
+                  title={el.title}
+                  by={el.by}
+                  score={el.score}
+                  url={el.url}
+                  id={el.id}
+                  saveSeen={this.saveSeen}
+                  onDelete={this.onUnsave}
+                  onStashed={this.saveStashed}
+                />
+              ))}
+            </CardShower>
+          </>
         )}
-        <CardShower>
-          {restCards.map((el) => (
-            <Card
-              key={el.id}
-              title={el.title}
-              by={el.by}
-              score={el.score}
-              url={el.url}
-              id={el.id}
-              saveSeen={this.saveSeen}
-              onDelete={this.onDelete}
-              onStashed={this.saveStashed}
-            />
-          ))}
-        </CardShower>
-        {/* <H2>Saved</H2>
-        <CardShower>
-          {this.state.elementsStashed.map((el) => (
-            <Card
-              key={el.id}
-              title={el.title}
-              by={el.by}
-              score={el.score}
-              url={el.url}
-              id={el.id}
-              saveSeen={this.saveSeen}
-              onDelete={this.onDelete}
-              onStashed={this.saveStashed}
-            />
-          ))}
-        </CardShower>
-        <H2>Deleted</H2>
-        <CardShower>
-          {this.state.elementsStashed.map((el) => (
-            <Card
-              key={el.id}
-              title={el.title}
-              by={el.by}
-              score={el.score}
-              url={el.url}
-              id={el.id}
-              saveSeen={this.saveSeen}
-              onDelete={this.onDelete}
-              onStashed={this.saveStashed}
-            />
-          ))} 
-        </CardShower>*/}
-        
       </div>
     );
   }


### PR DESCRIPTION
- Add touch swipe left/right on primary card (skip/save) with visual feedback
- Replace tiny "del"/"save" buttons with large 50px rounded action buttons below the primary card
- Add Feed/Saved tab navigation to access stashed stories
- Add onUnsave to remove stories from saved list
- Add progress counter showing stories remaining in feed
- Fix author font size (was 0.4em, now readable at 0.72em)
- Change secondary card grid from 1-col to 2-col on mobile (4-col on desktop)
- Improve card design: rounded corners, shadows, better color cue strip
- Add HN orange (#ff6600) accent to logo
- Bigger, more touch-friendly action buttons on secondary cards (34px height)
- Add keyboard arrow key support with proper cleanup in useEffect

https://claude.ai/code/session_011VXLdP82b9uWRWph7V4SRx